### PR TITLE
Remove format

### DIFF
--- a/java/src/main/java/com/omicia/examples/OmiciaApiExample.java
+++ b/java/src/main/java/com/omicia/examples/OmiciaApiExample.java
@@ -64,8 +64,7 @@ public class OmiciaApiExample {
 			.setPath("/projects/"+projectID+"/genomes")
 			.setParameter("genome_label", "Test R. Person")
 			.setParameter("genome_sex", "unspecified")
-			.setParameter("assembly_version", "hg19")
-			.setParameter("format", getFormatFromFile(inputFile.getName()))
+			.setParameter("assembly_version", "hg19"))
 		.build();
 
 		// build the authorization header
@@ -119,18 +118,6 @@ public class OmiciaApiExample {
 		System.out.println("response received:");
 		String output = readStream(entity.getContent());
 		System.out.println(output);
-	}
-
-	private static String getFormatFromFile(String name) {
-		if (name.endsWith(".vcf")) {
-			return "vcf";
-		} else if (name.endsWith(".vcf.gz")) {
-			return "vcf.gz";
-		} else if (name.endsWith(".vcf.bz2")) {
-			return "vcf.bz2";
-		} else {
-			throw new RuntimeException("unknown file format");
-		}
 	}
 
 	private static String readStream(InputStream stream) {

--- a/python/upload_genome.py
+++ b/python/upload_genome.py
@@ -20,15 +20,15 @@ OMICIA_API_URL = os.environ.get('OMICIA_API_URL', 'https://api.omicia.com')
 auth = HTTPBasicAuth(OMICIA_API_LOGIN, OMICIA_API_PASSWORD)
 
 
-def upload_genome_to_project(project_id, label, sex, file_format, file_name, bam_file,
+def upload_genome_to_project(project_id, label, sex, file_name, bam_file,
                              external_id=""):
     """Use the Omicia API to add a genome, in vcf format, to a project.
     Returns the newly uploaded genome's id.
     """
     # Construct request
     url = "{}/projects/{}/genomes?genome_label={}&genome_sex={}&external_id={}\
-           &assembly_version=hg19&format={}"
-    url = url.format(OMICIA_API_URL, project_id, label, sex, external_id, file_format)
+           &assembly_version=hg19"
+    url = url.format(OMICIA_API_URL, project_id, label, sex, external_id)
 
     if bam_file is not None:
         url = "{}&bam_file={}".format(url, bam_file)
@@ -46,7 +46,6 @@ def main():
     parser.add_argument('project_id', metavar='project_id')
     parser.add_argument('label', metavar='label')
     parser.add_argument('sex', metavar='sex')
-    parser.add_argument('file_format', metavar='file_format')
     parser.add_argument('file_name', metavar='file_name')
     parser.add_argument('--external_id', metavar='external_id')
     parser.add_argument('--bam_file', metavar='bam_file')
@@ -55,13 +54,11 @@ def main():
     project_id = args.project_id
     label = args.label
     sex = args.sex
-    file_format = args.file_format
     file_name = args.file_name
     external_id = args.external_id
     bam_file = args.bam_file
 
-    json_response = upload_genome_to_project(project_id, label, sex,
-                                             file_format, file_name, bam_file,
+    json_response = upload_genome_to_project(project_id, label, sex, file_name, bam_file,
                                              external_id=external_id)
     try:
         sys.stdout.write(json.dumps(json_response, indent=4))

--- a/python/upload_genomes_folder.py
+++ b/python/upload_genomes_folder.py
@@ -25,16 +25,7 @@ def get_genome_files(folder):
     """
     genome_files = []
     for file_name in os.listdir(folder):
-        if file_name.endswith(".vcf"):
-            genome_file_extension = "vcf"
-        elif file_name.endswith(".vcf.gz"):
-            genome_file_extension = "vcf.gz"
-        elif file_name.endswith(".vcf.bz2"):
-            genome_file_extension = "vcf.bz2"
-        else:
-            continue
         genome_info = {"name": file_name,
-                       "format": genome_file_extension,
                        "assembly_version": "hg19",
                        "genome_sex": "unspecified",
                        "genome_label": file_name[0:100]}
@@ -50,12 +41,11 @@ def upload_genomes_to_project(project_id, folder):
     genome_json_objects = []
 
     for genome_file in get_genome_files(folder):
-        url = "{}/projects/{}/genomes?genome_label={}&genome_sex={}&external_id=&assembly_version=hg19&format={}"
+        url = "{}/projects/{}/genomes?genome_label={}&genome_sex={}&external_id=&assembly_version=hg19"
         url = url.format(OMICIA_API_URL,
                          project_id,
                          genome_file["genome_label"],
-                         genome_file["genome_sex"],
-                         genome_file["format"])
+                         genome_file["genome_sex"])
 
         with open(folder + "/" + genome_file["name"], 'rb') as file_handle:
             # Post request and store id of newly uploaded genome

--- a/python/upload_genomes_folder_with_manifest.py
+++ b/python/upload_genomes_folder_with_manifest.py
@@ -9,11 +9,11 @@ all of the genomes it describes, and must be named 'manifest.csv.'
 
 Example manifest.csv contents:
 filename,label,external_id,sex,format
-TR4091_exome_copy.vcf.gz,abc1,55,male,vcf.gz
-TR4091_exome.vcf,abc2,56,female,vcf
-TR4092_exome.vcf,abc3,57,unspecified,vcf
-TR4093_exome.vcf,abc4,58,female,vcf
-TR4094_exome.vcf,abc5,59,male,vcf
+TR4091_exome_copy.vcf.gz,abc1,55,male
+TR4091_exome.vcf,abc2,56,female
+TR4092_exome.vcf,abc3,57,unspecified
+TR4093_exome.vcf,abc4,58,female
+TR4094_exome.vcf,abc5,59,male
 """
 import argparse
 import csv
@@ -54,8 +54,7 @@ def get_manifest_info(folder):
             genome_filename = row[0]
             manifest_info[genome_filename] = {"genome_label": row[1],
                                               "external_id": row[2],
-                                              "genome_sex": row[3],
-                                              "format": row[4]}
+                                              "genome_sex": row[3]}
     return manifest_info
 
 
@@ -72,13 +71,12 @@ def upload_genomes_to_project(project_id, folder):
     # Upload each genome to the desired project
     for genome_file_name in manifest_info.keys():
         genome_attrs = manifest_info[genome_file_name]
-        url = "{}/projects/{}/genomes?genome_label={}&genome_sex={}&external_id={}&assembly_version=hg19&format={}"
+        url = "{}/projects/{}/genomes?genome_label={}&genome_sex={}&external_id={}&assembly_version=hg19"
         url = url.format(OMICIA_API_URL,
                          project_id,
                          genome_attrs["genome_label"],
                          genome_attrs["genome_sex"],
-                         genome_attrs["external_id"],
-                         genome_attrs["format"])
+                         genome_attrs["external_id"])
 
         with open(folder + "/" + genome_file_name, 'rb') as file_handle:
             # Post request and store newly uploaded genome's information


### PR DESCRIPTION
I have improved the API upload to correctly guess file format - the format parameter is no longer required.
