### PR TITLE
UPMC example script update - Removing JSON to string conversion.

### DIFF
--- a/python/ClinicalReportLaunchers/add_report_variant_note.py
+++ b/python/ClinicalReportLaunchers/add_report_variant_note.py
@@ -29,7 +29,8 @@ def add_variant_note(cr_id, report_variant_id, note):
     url = url.format(FABRIC_API_URL, cr_id, report_variant_id)
 
     # Build the patch payload
-    url_payload = json.dumps({"note": note})
+    url_payload = {"note": note}
+
     sys.stdout.flush()
     result = requests.post(url, auth=auth, json=url_payload)
     return result

--- a/python/ClinicalReportLaunchers/patch_report_variant.py
+++ b/python/ClinicalReportLaunchers/patch_report_variant.py
@@ -32,10 +32,10 @@ def patch_cr_variant(cr_id, report_variant_id, patch_values):
 
     patch_attributes = [key for key, value in patch_values.items()]
     # Build the patch payload
-    url_payload = json.dumps([{"op": "replace",
+    url_payload = [{"op": "replace",
                                "path": "/{}".format(attribute),
                                "value": patch_values.get(attribute)}
-                              for attribute in patch_attributes])
+                              for attribute in patch_attributes]
     headers = {"content-type": "application/json-patch+json"}
     sys.stdout.flush()
     result = requests.patch(url, auth=auth, json=url_payload, headers=headers)

--- a/python/ClinicalReportLaunchers/update_clinical_report_status.py
+++ b/python/ClinicalReportLaunchers/update_clinical_report_status.py
@@ -30,7 +30,7 @@ def update_cr_status(cr_id, status):
     # Build the patch payload
     url_payload = [{"op": "replace",
                     "path": "/status",
-                    "value": "Ready to Review"}]
+                    "value": "status_name"}]
     headers = {"content-type": "application/json-patch+json"}
 
     sys.stdout.flush()

--- a/python/ClinicalReportLaunchers/update_clinical_report_status.py
+++ b/python/ClinicalReportLaunchers/update_clinical_report_status.py
@@ -28,9 +28,9 @@ def update_cr_status(cr_id, status):
     url = "{}/reports/{}/update_status/"
     url = url.format(FABRIC_API_URL, cr_id, status)
     # Build the patch payload
-    url_payload = json.dumps([{"op": "replace",
-                              "path": "/status",
-                              "value": status}])
+    url_payload = [{"op": "replace",
+                    "path": "/status",
+                    "value": "Ready to Review"}]
     headers = {"content-type": "application/json-patch+json"}
 
     sys.stdout.flush()


### PR DESCRIPTION
Updating example scripts to not convert JSON to strings in requests.